### PR TITLE
CI pipeline for building duckdb extension - works locally and in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,3 @@
-.github/workflows/ci.yml
-
 name: CI
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,82 +1,37 @@
+.github/workflows/ci.yml
+
 name: CI
 
 on:
   push:
-    branches:
-      - staging
-      - trying
+    branches: [ main ]
   pull_request:
-    branches: [main]
-
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+    branches: [ main ]
 
 jobs:
-
   build:
-    name: Build ${{ matrix.check }} on (${{ matrix.os }})
-    if: false
-    runs-on: ${{ matrix.os }}
-    strategy:
-        matrix:
-          os: [ubuntu-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.os }}-build
-      - name: Build
-        run: make debug
-
-  check:
-    name: Check ${{ matrix.check }} on (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        rust: [stable]
-        check: [test]
-        include:
-          - os: ubuntu-latest
-            rust: stable
-            check: fmt
-          - os: ubuntu-latest
-            rust: stable
-            check: clippy
-          - os: ubuntu-latest
-            rust: stable
-            check: audit
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install ${{ matrix.rust }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.os }}-${{ matrix.check }}
-      - name: Clippy
-        if: ${{ matrix.check == 'clippy' }}
-        run: make check-clippy
-      - name: Fmt
-        if: ${{ matrix.check == 'fmt' }}
-        run: make check-fmt
-
-  done:
-    name: Done
-    needs:
-      - check
     runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      FORCE_COLOR: 1
     steps:
-      - name: Done
-        run: echo "Done!"
+    - uses: earthly/actions/setup-earthly@v1
+      with:
+        version: v0.7.0
+    - uses: actions/checkout@v2
+    - name: Put back the git branch into git (Earthly uses it for tagging)
+      run: |
+        branch=""
+        if [ -n "$GITHUB_HEAD_REF" ]; then
+          branch="$GITHUB_HEAD_REF"
+        else
+          branch="${GITHUB_REF##*/}"
+        fi
+        git checkout -b "$branch" || true
+    - name: Docker Login
+      run: docker login --username "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_TOKEN"
+    - name: Earthly version
+      run: earthly --version
+    - name: Run build
+      run: earthly --push +build

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,35 @@
+VERSION 0.6
+FROM ubuntu:20.04
+
+WORKDIR /fluvio-duck
+
+code:
+    COPY --dir src duckdb .git ./ 
+    COPY build_extension.sh .gitmodules toolchain.toml Cargo.lock Cargo.toml CMakeLists.txt Makefile ./
+build:
+  FROM +code
+  ARG USERPLATFORM
+  ARG NATIVEPLATFORM
+  ARG TARGETPLATFORM
+  ARG EARTHLY_TARGET
+  ARG TARGETARCH
+  ARG TARGETOS
+  ARG TARGETPLATFORM
+  RUN echo "The current target is $EARTHLY_TARGET"
+  RUN echo "The current target arch is $TARGETARCH" 
+  RUN echo "The current target os is $TARGETOS"
+  RUN echo "The current target os is $TARGETPLATFORM"
+  ## for apt to be noninteractive
+  ENV DEBIAN_FRONTEND noninteractive
+  ENV DEBCONF_NONINTERACTIVE_SEEN true
+  RUN apt-get update 
+  RUN DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true TZ=Etc/UTC apt-get install -yqq --no-install-recommends build-essential git wget curl software-properties-common lsb-release apt-utils
+  RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+  RUN apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
+  RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -yq cmake
+  RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+  #RUN make release
+  # cache cmake temp files to prevent rebuilding .o files
+  # when the .cpp files don't change
+  RUN --mount=type=cache,target=/fluvio-duck/build/release/CMakeFiles /usr/bin/bash build_extension.sh
+  SAVE ARTIFACT ./build/release/extension/fluvio-duck/fluvioduck.duckdb_extension AS LOCAL "fluvioduck.duckdb_extension"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 BUILD_FLAGS=-DEXTENSION_STATIC_BUILD=1 ${OSX_BUILD_UNIVERSAL_FLAG}
 
 pull:
-	#git submodule init
+	git submodule init
 	git submodule update --recursive --remote
 
 clean:
@@ -25,7 +25,7 @@ debug:pull
 	cmake $(GENERATOR) $(FORCE_COLOR) -DCMAKE_BUILD_TYPE=Debug ${BUILD_FLAGS} ../../duckdb/CMakeLists.txt -DEXTERNAL_EXTENSION_DIRECTORIES=../../fluvio-duck -B. && \
 	cmake --build . --config Debug
 
-release:
+release:pull
 	mkdir -p build/release && \
 	cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) -DCMAKE_BUILD_TYPE=RelWithDebInfo ${BUILD_FLAGS} ../../duckdb/CMakeLists.txt -DEXTERNAL_EXTENSION_DIRECTORIES=../../fluvio-duck -B. && \

--- a/Makefile
+++ b/Makefile
@@ -12,20 +12,20 @@ endif
 BUILD_FLAGS=-DEXTENSION_STATIC_BUILD=1 ${OSX_BUILD_UNIVERSAL_FLAG}
 
 pull:
-	git submodule init
-#	git submodule update --recursive --remote
+	#git submodule init
+	git submodule update --recursive --remote
 
 clean:
 	rm -rf build
 	cargo clean
 
-debug: pull
+debug:pull
 	mkdir -p build/debug && \
 	cd build/debug && \
 	cmake $(GENERATOR) $(FORCE_COLOR) -DCMAKE_BUILD_TYPE=Debug ${BUILD_FLAGS} ../../duckdb/CMakeLists.txt -DEXTERNAL_EXTENSION_DIRECTORIES=../../fluvio-duck -B. && \
 	cmake --build . --config Debug
 
-release: pull
+release:
 	mkdir -p build/release && \
 	cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) -DCMAKE_BUILD_TYPE=RelWithDebInfo ${BUILD_FLAGS} ../../duckdb/CMakeLists.txt -DEXTERNAL_EXTENSION_DIRECTORIES=../../fluvio-duck -B. && \

--- a/build_extension.sh
+++ b/build_extension.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
 source "$HOME/.cargo/env"
-mkdir -p build/release
-cd build/release
-cmake $(GENERATOR) $(FORCE_COLOR) -DCMAKE_BUILD_TYPE=RelWithDebInfo ${BUILD_FLAGS} ../../duckdb/CMakeLists.txt -DEXTERNAL_EXTENSION_DIRECTORIES=../../fluvio-duck -B.
-cmake --build . --config Release
+make release

--- a/build_extension.sh
+++ b/build_extension.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$HOME/.cargo/env"
+mkdir -p build/release
+cd build/release
+cmake $(GENERATOR) $(FORCE_COLOR) -DCMAKE_BUILD_TYPE=RelWithDebInfo ${BUILD_FLAGS} ../../duckdb/CMakeLists.txt -DEXTERNAL_EXTENSION_DIRECTORIES=../../fluvio-duck -B.
+cmake --build . --config Release


### PR DESCRIPTION
I am using [Earthly](https://earthly.dev/get-earthly), which allows running docker-like build kit locally via `earthly -i +build` and using the same Earthlyfile in GitHub actions. 
1. For local build install eathly then run `earthly -i +build` 
2. For GitHub actions add DOCKERHUB_USERNAME and DOCKERHUB_TOKEN into repository secrets (or remove --push flag)

Currently, the +build step only saves extension, without the dev version of duckdb (both can be saved via save artefact).
Looking forward to reviewing and feedback.
If approved we can expand earthly to build binaries for the different platforms from the same Earthflie via the --platform tag, see [Cross-compile Repo](https://github.com/earthly/earthly/blob/main/examples/multiplatform-cross-compile/Earthfile)
